### PR TITLE
fix: handle deep refs w/ matching names but different content

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1671,6 +1671,51 @@
         "@types/node": ">= 8"
       }
     },
+    "@sinonjs/commons": {
+      "version": "1.8.1",
+      "resolved": "http://nexus.core.cvent.org:8081/nexus/repository/npm-public/@sinonjs/commons/-/commons-1.8.1.tgz",
+      "integrity": "sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "6.0.1",
+      "resolved": "http://nexus.core.cvent.org:8081/nexus/repository/npm-public/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+      "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "5.0.1",
+      "resolved": "http://nexus.core.cvent.org:8081/nexus/repository/npm-public/@sinonjs/formatio/-/formatio-5.0.1.tgz",
+      "integrity": "sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^5.0.2"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "5.3.0",
+      "resolved": "http://nexus.core.cvent.org:8081/nexus/repository/npm-public/@sinonjs/samsam/-/samsam-5.3.0.tgz",
+      "integrity": "sha512-hXpcfx3aq+ETVBwPlRFICld5EnrkexXuXDwqUNhDdr5L8VjvMeSRwyOa0qL7XFmR+jVWR4rUZtnxlG7RX72sBg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "http://nexus.core.cvent.org:8081/nexus/repository/npm-public/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -7245,6 +7290,12 @@
         "verror": "1.10.0"
       }
     },
+    "just-extend": {
+      "version": "4.1.1",
+      "resolved": "http://nexus.core.cvent.org:8081/nexus/repository/npm-public/just-extend/-/just-extend-4.1.1.tgz",
+      "integrity": "sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA==",
+      "dev": true
+    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -8248,6 +8299,36 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.4.tgz",
       "integrity": "sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA==",
       "dev": true
+    },
+    "nise": {
+      "version": "4.0.4",
+      "resolved": "http://nexus.core.cvent.org:8081/nexus/repository/npm-public/nise/-/nise-4.0.4.tgz",
+      "integrity": "sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "http://nexus.core.cvent.org:8081/nexus/repository/npm-public/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "http://nexus.core.cvent.org:8081/nexus/repository/npm-public/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
     },
     "node-fetch": {
       "version": "2.6.1",
@@ -9735,6 +9816,38 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
+    "sinon": {
+      "version": "9.2.2",
+      "resolved": "http://nexus.core.cvent.org:8081/nexus/repository/npm-public/sinon/-/sinon-9.2.2.tgz",
+      "integrity": "sha512-9Owi+RisvCZpB0bdOVFfL314I6I4YoRlz6Isi4+fr8q8YQsDPoCe5UnmNtKHRThX3negz2bXHWIuiPa42vM8EQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.8.1",
+        "@sinonjs/fake-timers": "^6.0.1",
+        "@sinonjs/formatio": "^5.0.1",
+        "@sinonjs/samsam": "^5.3.0",
+        "diff": "^4.0.2",
+        "nise": "^4.0.4",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "http://nexus.core.cvent.org:8081/nexus/repository/npm-public/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "http://nexus.core.cvent.org:8081/nexus/repository/npm-public/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "slash": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
@@ -10604,6 +10717,12 @@
       "requires": {
         "prelude-ls": "^1.2.1"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "http://nexus.core.cvent.org:8081/nexus/repository/npm-public/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-fest": {
       "version": "0.3.1",

--- a/packages/oas-resolver/index.js
+++ b/packages/oas-resolver/index.js
@@ -180,10 +180,19 @@ function resolveToName(ref, refs) {
         }
     }
 
-    let potentialSchemaName = `#/components/schemas/${path.parse(path.basename(ref)).name}`;
+    let refParts = ref.split('#');
+
+    let baseRefPath = path.parse(path.basename(refParts[0])).name
+
+    let deepRefPath = refParts.length > 1 ? path.parse(path.basename(refParts[1])).name : null;
+
+    let finalPath = deepRefPath ? `${baseRefPath}-${deepRefPath}` : baseRefPath;
+
+    let potentialSchemaName = `#/components/schemas/${finalPath}`;
+    
     if (currentListOfResolved.includes(potentialSchemaName)) {
         let hash = crypto.createHash('sha1').update(ref).digest('hex');
-        return `#/components/schemas/${path.parse(path.basename(ref)).name}-${hash}`
+        return `#/components/schemas/${finalPath}-${hash}`
     }
     return potentialSchemaName
 }

--- a/packages/oas-resolver/index.js
+++ b/packages/oas-resolver/index.js
@@ -189,7 +189,7 @@ function resolveToName(ref, refs) {
     let finalPath = deepRefPath ? `${baseRefPath}-${deepRefPath}` : baseRefPath;
 
     let potentialSchemaName = `#/components/schemas/${finalPath}`;
-    
+
     if (currentListOfResolved.includes(potentialSchemaName)) {
         let hash = crypto.createHash('sha1').update(ref).digest('hex');
         return `#/components/schemas/${finalPath}-${hash}`

--- a/packages/oas-resolver/package-lock.json
+++ b/packages/oas-resolver/package-lock.json
@@ -52,7 +52,7 @@
 		},
 		"fast-safe-stringify": {
 			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+			"resolved": "http://nexus.core.cvent.org:8081/nexus/repository/npm-public/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
 			"integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
 		},
 		"get-caller-file": {
@@ -87,6 +87,11 @@
 			"requires": {
 				"fast-safe-stringify": "^2.0.7"
 			}
+		},
+		"reftools": {
+			"version": "1.1.7",
+			"resolved": "http://nexus.core.cvent.org:8081/nexus/repository/npm-public/reftools/-/reftools-1.1.7.tgz",
+			"integrity": "sha512-I+KZFkQvZjMZqVWxRezTC/kQ2kLhGRZ7C+4ARbgmb5WJbvFUlbrZ/6qlz6mb+cGcPNYib+xqL8kZlxCsSZ7Hew=="
 		},
 		"require-directory": {
 			"version": "2.1.1",

--- a/test/resolver/resolveSharedRefs-case-1/output.yaml
+++ b/test/resolver/resolveSharedRefs-case-1/output.yaml
@@ -55,7 +55,7 @@ paths:
       deprecated: false
 components:
   schemas:
-    xyz:
+    schemas-xyz:
       title: XYZ
       description: this is xyz
       type: object
@@ -63,7 +63,7 @@ components:
         id:
           description: the local identifier (not necessarily globally unique)
           type: string
-    abc:
+    schemas-abc:
       title: abc
       description: this is abc
       type: object
@@ -71,7 +71,7 @@ components:
         id:
           description: the local identifier (not necessarily globally unique)
           type: string
-    xyz-123:
+    schemas2-xyz:
       title: XYZ
       description: this is xyz
       type: object
@@ -79,7 +79,7 @@ components:
         id:
           description: the local identifier (not necessarily globally unique)
           type: string
-    abc-123:
+    schemas2-abc:
       title: abc
       description: this is abc
       type: object
@@ -111,49 +111,49 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/xyz'
+            $ref: '#/components/schemas/schemas-xyz'
     Post202:
       description: Success post
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/xyz'
+            $ref: '#/components/schemas/schemas-xyz'
     Post203:
       description: Success post
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/xyz-123'
+            $ref: '#/components/schemas/schemas2-xyz'
     Post204:
       description: Success post
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/xyz-123'
+            $ref: '#/components/schemas/schemas2-xyz'
     Post205:
       description: Success post
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/abc'
+            $ref: '#/components/schemas/schemas-abc'
     Post206:
       description: Success post
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/abc'
+            $ref: '#/components/schemas/schemas-abc'
     Post207:
       description: Success post
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/abc-123'
+            $ref: '#/components/schemas/schemas2-abc'
     Post208:
       description: Success post
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/abc-123'
+            $ref: '#/components/schemas/schemas2-abc'
     TestModel:
         description: A test model
         content:

--- a/test/resolver/resolveSharedRefs-case-2/output.yaml
+++ b/test/resolver/resolveSharedRefs-case-2/output.yaml
@@ -55,7 +55,7 @@ paths:
       deprecated: false
 components:
   schemas:
-    xyz:
+    schemas-xyz:
       title: XYZ
       description: this is xyz
       type: object
@@ -63,7 +63,7 @@ components:
         id:
           description: the local identifier (not necessarily globally unique)
           type: string
-    abc:
+    schemas-abc:
       title: abc
       description: this is abc
       type: object
@@ -95,25 +95,25 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/xyz'
+            $ref: '#/components/schemas/schemas-xyz'
     Post202:
       description: Success post
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/xyz'
+            $ref: '#/components/schemas/schemas-xyz'
     Post203:
       description: Success post
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/abc'
+            $ref: '#/components/schemas/schemas-abc'
     Post204:
       description: Success post
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/abc'
+            $ref: '#/components/schemas/schemas-abc'
     TestModel:
         description: A test model
         content:

--- a/test/resolver/resolveSharedRefs-case-5/output.yaml
+++ b/test/resolver/resolveSharedRefs-case-5/output.yaml
@@ -55,7 +55,7 @@ paths:
       deprecated: false
 components:
   schemas:
-    abc:
+    schemas-abc:
       title: abc
       description: this is abc
       type: object
@@ -64,7 +64,7 @@ components:
           description: the local identifier (not necessarily globally unique)
           type: string
         details:
-          $ref: '#/components/schemas/abc'
+          $ref: '#/components/schemas/schemas-abc'
           description: a list of details
           type: array
     paging:
@@ -103,13 +103,13 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/abc'
+            $ref: '#/components/schemas/schemas-abc'
     Post203:
       description: Success post
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/abc'
+            $ref: '#/components/schemas/schemas-abc'
     TestModel:
         description: A test model
         content:


### PR DESCRIPTION
deep-refed components were being overwritten; this avoids that by ensuring that the generated path is unique to the file + deep ref