### PR TITLE
handle hoisting example blocks

### DIFF
--- a/packages/oas-resolver/index.js
+++ b/packages/oas-resolver/index.js
@@ -20,7 +20,7 @@ const HOISTABLE_COMPONENT_SECTIONS = {
 }
 
 const COMPONENT_SECTION_HANDLER = {
-  'examples': data => { 'value': data }
+  'examples': data => ({ 'value': data })
 }
 
 const HOISTABLE_COMPONENT_SECTION_LOOKUP = Object.entries(HOISTABLE_COMPONENT_SECTIONS).reduce(

--- a/packages/oas-resolver/index.js
+++ b/packages/oas-resolver/index.js
@@ -19,10 +19,6 @@ const HOISTABLE_COMPONENT_SECTIONS = {
     'examples': [ 'examples' ]
 }
 
-const COMPONENT_SECTION_HANDLER = {
-  'examples': data => ({ 'value': data })
-}
-
 const HOISTABLE_COMPONENT_SECTION_LOOKUP = Object.entries(HOISTABLE_COMPONENT_SECTIONS).reduce(
     (result, entry) => {
         const [ section, keys ] = entry;
@@ -327,21 +323,6 @@ function buildComponentName(section, ref, openapi, idx = -1) {
     return existingJptr ? buildComponentName(section, ref, openapi, idx) : name;
 }
 
-function determineHoistedData(ptr, data) {
-  const ptrParts = ptr.split('/');
-
-  // we only want to work on things we've rerouted; and we always re-route to a top level component
-  if (ptrParts.length !== 4) {
-    return data;
-  }
-
-  // parts will be [#, components, section, name]; where we want the section
-  const componentType = ptrParts[2];
-
-  const handler = COMPONENT_SECTION_HANDLER[componentType];
-
-  return handler ? handler(data) : data;
-}
 
 function determineHoistedPtr(ptr, ref, openapi) {
 
@@ -509,16 +490,7 @@ function findExternalRefs(options) {
                                     }
                                     // then spread the data out at the location of the pointer
                                     let cdata = clone(data);
-                                    jptr(
-                                      options.openapi,
-                                      finalPtr,
-
-                                      // if we're hositing, and the pointer changed (which means we want to hoist)
-                                      // check if we need to manipulate the data to fit in the component specified
-                                      options.hoistResolvedComponents && finalPtr !== ptr?
-                                        determineHoistedData(finalPtr, cdata) :
-                                        cdata
-                                    ); // resolutionCase:F (cloned:yes)
+                                    jptr(options.openapi, finalPtr, cdata); // resolutionCase:F (cloned:yes)
 
                                     // if we re-routed the destination of the data, update the ptr to point there
                                     if (finalPtr !== ptr) {


### PR DESCRIPTION
add logic to hoist "examples" to the examples component section, as well as re-reprocessing the example into a valid structure.